### PR TITLE
chore: add invoked signed for unchecked accounts

### DIFF
--- a/auction-house/program/src/cancel/mod.rs
+++ b/auction-house/program/src/cancel/mod.rs
@@ -10,7 +10,7 @@ pub struct Cancel<'info> {
     /// CHECK: Verified in cancel_logic.
     /// User wallet account.
     #[account(mut)]
-    pub wallet: Signer<'info>,
+    pub wallet: UncheckedAccount<'info>,
 
     /// SPL token account containing the token of the sale to be canceled.
     #[account(mut)]
@@ -30,9 +30,9 @@ pub struct Cancel<'info> {
             auction_house.creator.as_ref(),
             auction_house.treasury_mint.as_ref()
         ],
-        bump=auction_house.bump,
-        has_one=authority,
-        has_one=auction_house_fee_account
+        bump = auction_house.bump,
+        has_one = authority,
+        has_one = auction_house_fee_account
     )]
     pub auction_house: Box<Account<'info, AuctionHouse>>,
 
@@ -45,7 +45,7 @@ pub struct Cancel<'info> {
             auction_house.key().as_ref(),
             FEE_PAYER.as_bytes()
         ],
-        bump=auction_house.fee_payer_bump
+        bump = auction_house.fee_payer_bump
     )]
     pub auction_house_fee_account: UncheckedAccount<'info>,
 
@@ -79,7 +79,7 @@ pub struct AuctioneerCancel<'info> {
     /// CHECK: Wallet validated as owner in cancel logic.
     /// User wallet account.
     #[account(mut)]
-    pub wallet: Signer<'info>,
+    pub wallet: UncheckedAccount<'info>,
 
     /// SPL token account containing the token of the sale to be canceled.
     #[account(mut)]

--- a/auction-house/program/src/sell/mod.rs
+++ b/auction-house/program/src/sell/mod.rs
@@ -14,7 +14,7 @@ use crate::{constants::*, errors::*, utils::*, AuctionHouse, AuthorityScope, *};
 )]
 pub struct Sell<'info> {
     /// User wallet account.
-    pub wallet: Signer<'info>,
+    pub wallet: UncheckedAccount<'info>,
 
     /// SPL token account containing token for sale.
     #[account(mut)]
@@ -131,7 +131,7 @@ pub struct AuctioneerSell<'info> {
     /// CHECK: Wallet is validated as a signer in sell_logic.
     /// User wallet account.
     #[account(mut)]
-    pub wallet: Signer<'info>,
+    pub wallet: UncheckedAccount<'info>,
 
     /// SPL token account containing token for sale.
     #[account(mut)]

--- a/listing-rewards/program/src/listings/cancel/mod.rs
+++ b/listing-rewards/program/src/listings/cancel/mod.rs
@@ -171,33 +171,21 @@ pub fn handler(
         token_size,
     };
 
-    let auth_account_key = if auction_house.requires_sign_off {
-        auction_house_authority_key
-    } else {
-        wallet_key
-    };
-
-    let signer_required_keys = vec![ctx.accounts.reward_center.key(), auth_account_key];
-
     let cancel_listing_ix = Instruction {
         program_id: auction_house_program.key(),
         data: cancel_listing_params.data(),
         accounts: cancel_listing_ctx_accounts
-            .to_account_metas(None)
-            .into_iter()
-            .map(|mut account| {
-                if signer_required_keys.contains(&account.pubkey) {
-                    account.is_signer = if account.pubkey.eq(&reward_center.key()) {
-                        true
-                    } else if account.pubkey.eq(&wallet_key) {
-                        ctx.accounts.wallet.to_account_info().is_signer
-                    } else {
-                        ctx.accounts.authority.to_account_info().is_signer
-                    }
-                }
-                account
-            })
-            .collect(),
+        .to_account_metas(None)
+        .into_iter()
+        .zip(cancel_listing_ctx_accounts.to_account_infos())
+        .map(|mut pair| {
+            pair.0.is_signer = pair.1.is_signer;
+            if pair.0.pubkey == ctx.accounts.reward_center.key() {
+                pair.0.is_signer = true;
+            }
+            pair.0
+        })
+        .collect()
     };
 
     invoke_signed(

--- a/listing-rewards/program/src/listings/cancel/mod.rs
+++ b/listing-rewards/program/src/listings/cancel/mod.rs
@@ -136,8 +136,6 @@ pub fn handler(
     let rewardable_collection = &ctx.accounts.rewardable_collection;
     let clock = Clock::get()?;
     let auction_house_key = auction_house.key();
-    let wallet_key = ctx.accounts.wallet.key();
-    let auction_house_authority_key = ctx.accounts.authority.key();
 
     assert_belongs_to_rewardable_collection(metadata, rewardable_collection)?;
 

--- a/listing-rewards/program/src/listings/create/mod.rs
+++ b/listing-rewards/program/src/listings/create/mod.rs
@@ -196,6 +196,8 @@ pub fn handler(
     let wallet = &ctx.accounts.wallet;
     let clock = Clock::get()?;
     let auction_house_key = auction_house.key();
+    let wallet_key = ctx.accounts.wallet.key();
+    let auction_house_authority_key = ctx.accounts.authority.key();
 
     assert_belongs_to_rewardable_collection(metadata, rewardable_collection)?;
 
@@ -247,23 +249,40 @@ pub fn handler(
         token_size,
     };
 
-    let signer_required_keys = vec![
-        ctx.accounts.reward_center.key(),
-        ctx.accounts.wallet.key(),
-    ];
+    let auth_account_key = if auction_house.requires_sign_off || price == 0 {
+        auction_house_authority_key
+    } else {
+        wallet_key
+    };
+
+    let signer_required_keys = vec![ctx.accounts.reward_center.key(), auth_account_key];
 
     let create_listing_ix = Instruction {
         program_id: auction_house_program.key(),
         data: create_listing_params.data(),
-        accounts: create_listing_ctx_accounts.to_account_metas(None).into_iter().map(|mut account| {
-            if signer_required_keys.contains(&account.pubkey) {
-                account.is_signer = true;
-            }
-            account
-        }).collect()
+        accounts: create_listing_ctx_accounts
+            .to_account_metas(None)
+            .into_iter()
+            .map(|mut account| {
+                if signer_required_keys.contains(&account.pubkey) {
+                    account.is_signer = if account.pubkey.eq(&reward_center.key()) {
+                        true
+                    } else if account.pubkey.eq(&wallet_key) {
+                        ctx.accounts.wallet.to_account_info().is_signer
+                    } else {
+                        ctx.accounts.authority.to_account_info().is_signer
+                    }
+                }
+                account
+            })
+            .collect(),
     };
 
-    invoke_signed(&create_listing_ix, &create_listing_ctx_accounts.to_account_infos(), &reward_center_signer_seeds)?;
+    invoke_signed(
+        &create_listing_ix,
+        &create_listing_ctx_accounts.to_account_infos(),
+        &reward_center_signer_seeds,
+    )?;
 
     Ok(())
 }

--- a/listing-rewards/program/src/listings/create/mod.rs
+++ b/listing-rewards/program/src/listings/create/mod.rs
@@ -1,5 +1,6 @@
-use anchor_lang::{context::Context, prelude::*, AnchorDeserialize};
+use anchor_lang::{context::Context, prelude::*, AnchorDeserialize, InstructionData};
 use anchor_spl::token::{Token, TokenAccount};
+use solana_program::{instruction::Instruction, program::invoke_signed};
 
 use crate::{
     assertions::assert_belongs_to_rewardable_collection,
@@ -11,6 +12,7 @@ use crate::{
 use mpl_auction_house::{
     constants::{AUCTIONEER, FEE_PAYER, PREFIX, SIGNER},
     cpi::accounts::AuctioneerSell,
+    instruction::AuctioneerSell as AuctioneerSellParams,
     program::AuctionHouse as AuctionHouseProgram,
     AuctionHouse,
 };
@@ -35,9 +37,9 @@ pub struct CreateListing<'info> {
     /// The Listing Config used for listing settings
     #[account(
         init,
-        payer=wallet,
-        space=Listing::size(),
-        seeds=[
+        payer = wallet,
+        space = Listing::size(),
+        seeds = [
             LISTING.as_bytes(),
             wallet.key().as_ref(),
             metadata.key().as_ref(),
@@ -52,12 +54,11 @@ pub struct CreateListing<'info> {
     pub reward_center: Box<Account<'info, RewardCenter>>,
 
     /// The collection eligable for rewards
-    #[
-        account(
-            seeds = [
-                REWARDABLE_COLLECTION.as_bytes(),
-                reward_center.key().as_ref(),
-                metadata.collection.as_ref().ok_or(ListingRewardsError::NFTMissingCollection)?.key.as_ref()
+    #[account(
+        seeds = [
+            REWARDABLE_COLLECTION.as_bytes(),
+            reward_center.key().as_ref(),
+            metadata.collection.as_ref().ok_or(ListingRewardsError::NFTMissingCollection)?.key.as_ref()
         ],
         bump = rewardable_collection.bump
     )]
@@ -69,12 +70,11 @@ pub struct CreateListing<'info> {
     pub wallet: Signer<'info>,
 
     /// SPL token account containing token for sale.
-    #[
-        account(
-            mut,
-            constraint = token_account.owner == wallet.key(),
-            constraint = token_account.amount == 1
-        )]
+    #[account(
+        mut,
+        constraint = token_account.owner == wallet.key(),
+        constraint = token_account.amount == 1
+    )]
     pub token_account: Box<Account<'info, TokenAccount>>,
 
     /// Metaplex metadata account decorating SPL mint account.
@@ -85,31 +85,92 @@ pub struct CreateListing<'info> {
     pub authority: UncheckedAccount<'info>,
 
     /// Auction House instance PDA account.
-    #[account(seeds=[PREFIX.as_bytes(), auction_house.creator.as_ref(), auction_house.treasury_mint.as_ref()], seeds::program=auction_house_program, bump=auction_house.bump, has_one=auction_house_fee_account)]
+    #[account(
+        seeds = [
+            PREFIX.as_bytes(),
+            auction_house.creator.as_ref(),
+            auction_house.treasury_mint.as_ref()
+        ],
+        seeds::program = auction_house_program,
+        bump = auction_house.bump,
+        has_one = auction_house_fee_account
+    )]
     pub auction_house: Box<Account<'info, AuctionHouse>>,
 
     /// CHECK: Not dangerous. Account seeds checked in constraint.
     /// Auction House instance fee account.
-    #[account(mut, seeds=[PREFIX.as_bytes(), auction_house.key().as_ref(), FEE_PAYER.as_bytes()], seeds::program=auction_house_program, bump=auction_house.fee_payer_bump)]
+    #[account(
+        mut,
+        seeds = [
+            PREFIX.as_bytes(),
+            auction_house.key().as_ref(),
+            FEE_PAYER.as_bytes()
+        ],
+        seeds::program = auction_house_program,
+        bump = auction_house.fee_payer_bump
+    )]
     pub auction_house_fee_account: UncheckedAccount<'info>,
 
     /// CHECK: Not dangerous. Account seeds checked in constraint.
     /// Seller trade state PDA account encoding the sell order.
-    #[account(mut, seeds=[PREFIX.as_bytes(), wallet.key().as_ref(), auction_house.key().as_ref(), token_account.key().as_ref(), auction_house.treasury_mint.as_ref(), token_account.mint.as_ref(),  &u64::MAX.to_le_bytes(), &sell_params.token_size.to_le_bytes()], seeds::program=auction_house_program, bump=sell_params.trade_state_bump)]
+    #[account(
+        mut, 
+        seeds = [
+            PREFIX.as_bytes(),
+            wallet.key().as_ref(),
+            auction_house.key().as_ref(),
+            token_account.key().as_ref(),
+            auction_house.treasury_mint.as_ref(),
+            token_account.mint.as_ref(),
+            &u64::MAX.to_le_bytes(),
+            &sell_params.token_size.to_le_bytes()
+        ],
+        seeds::program = auction_house_program,
+        bump = sell_params.trade_state_bump
+    )]
     pub seller_trade_state: UncheckedAccount<'info>,
 
     /// CHECK: Not dangerous. Account seeds checked in constraint.
     /// Free seller trade state PDA account encoding a free sell order.
-    #[account(mut, seeds=[PREFIX.as_bytes(), wallet.key().as_ref(), auction_house.key().as_ref(), token_account.key().as_ref(), auction_house.treasury_mint.as_ref(), token_account.mint.as_ref(), &0u64.to_le_bytes(), &sell_params.token_size.to_le_bytes()], seeds::program=auction_house_program, bump=sell_params.free_trade_state_bump)]
+    #[account(
+        mut, 
+        seeds = [
+            PREFIX.as_bytes(),
+            wallet.key().as_ref(),
+            auction_house.key().as_ref(),
+            token_account.key().as_ref(),
+            auction_house.treasury_mint.as_ref(),
+            token_account.mint.as_ref(),
+            &0u64.to_le_bytes(),
+            &sell_params.token_size.to_le_bytes()
+        ],
+        seeds::program = auction_house_program,
+        bump = sell_params.free_trade_state_bump
+    )]
     pub free_seller_trade_state: UncheckedAccount<'info>,
 
     /// CHECK: Not dangerous. Account seeds checked in constraint.
     /// The auctioneer PDA owned by Auction House storing scopes.
-    #[account(seeds = [AUCTIONEER.as_bytes(), auction_house.key().as_ref(), reward_center.key().as_ref()], seeds::program=auction_house_program, bump = auction_house.auctioneer_pda_bump)]
+    #[account(
+        seeds = [
+            AUCTIONEER.as_bytes(),
+            auction_house.key().as_ref(),
+            reward_center.key().as_ref()
+        ],
+        seeds::program = auction_house_program,
+        bump = auction_house.auctioneer_pda_bump
+    )]
     pub ah_auctioneer_pda: UncheckedAccount<'info>,
 
     /// CHECK: Not dangerous. Account seeds checked in constraint.
-    #[account(seeds=[PREFIX.as_bytes(), SIGNER.as_bytes()], seeds::program=auction_house_program, bump=sell_params.program_as_signer_bump)]
+    #[account(
+        seeds=[
+            PREFIX.as_bytes(),
+            SIGNER.as_bytes()
+        ],
+        seeds::program = auction_house_program,
+        bump = sell_params.program_as_signer_bump
+    )]
     pub program_as_signer: UncheckedAccount<'info>,
 
     pub token_program: Program<'info, Token>,
@@ -154,52 +215,55 @@ pub fn handler(
     listing.canceled_at = None;
     listing.reward_redeemed_at = None;
 
-    let seeds = &[
+    let reward_center_signer_seeds: &[&[&[u8]]] = &[&[
         REWARD_CENTER.as_bytes(),
         auction_house_key.as_ref(),
         &[reward_center.bump],
-    ];
-    let signer_seeds = &[&seeds[..]];
+    ]];
 
-    mpl_auction_house::cpi::auctioneer_sell(
-        ctx.accounts
-            .set_auctioneer_sell_ctx()
-            .with_signer(signer_seeds),
+    let auction_house_program = ctx.accounts.auction_house_program.to_account_info();
+
+    let create_listing_ctx_accounts = AuctioneerSell {
+        wallet: ctx.accounts.wallet.to_account_info(),
+        token_account: ctx.accounts.token_account.to_account_info(),
+        metadata: ctx.accounts.metadata.to_account_info(),
+        auction_house: ctx.accounts.auction_house.to_account_info(),
+        auction_house_fee_account: ctx.accounts.auction_house_fee_account.to_account_info(),
+        seller_trade_state: ctx.accounts.seller_trade_state.to_account_info(),
+        free_seller_trade_state: ctx.accounts.free_seller_trade_state.to_account_info(),
+        authority: ctx.accounts.authority.to_account_info(),
+        auctioneer_authority: ctx.accounts.reward_center.to_account_info(),
+        ah_auctioneer_pda: ctx.accounts.ah_auctioneer_pda.to_account_info(),
+        token_program: ctx.accounts.token_program.to_account_info(),
+        system_program: ctx.accounts.system_program.to_account_info(),
+        program_as_signer: ctx.accounts.program_as_signer.to_account_info(),
+        rent: ctx.accounts.rent.to_account_info(),
+    };
+
+    let create_listing_params = AuctioneerSellParams {
         trade_state_bump,
         free_trade_state_bump,
         program_as_signer_bump,
         token_size,
-    )?;
+    };
+
+    let signer_required_keys = [
+        ctx.accounts.reward_center.key(),
+        ctx.accounts.wallet.key(),
+    ];
+
+    let create_listing_ix = Instruction {
+        program_id: auction_house_program.key(),
+        data: create_listing_params.data(),
+        accounts: create_listing_ctx_accounts.to_account_metas(None).into_iter().map(|mut account| {
+            if signer_required_keys.contains(&account.pubkey) {
+                account.is_signer = true;
+            }
+            account
+        }).collect()
+    };
+
+    invoke_signed(&create_listing_ix, &create_listing_ctx_accounts.to_account_infos(), &reward_center_signer_seeds)?;
 
     Ok(())
-}
-
-impl<'info> CreateListing<'info> {
-    pub fn set_auctioneer_sell_ctx(&self) -> CpiContext<'_, '_, '_, 'info, AuctioneerSell<'info>> {
-        let cpi_program = self.auction_house_program.to_account_info();
-        let accounts = (&*self).into();
-
-        CpiContext::new(cpi_program, accounts)
-    }
-}
-
-impl<'info> From<&CreateListing<'info>> for AuctioneerSell<'info> {
-    fn from(accounts: &CreateListing<'info>) -> Self {
-        Self {
-            wallet: accounts.wallet.to_account_info().clone(),
-            token_account: accounts.token_account.to_account_info(),
-            metadata: accounts.metadata.to_account_info(),
-            auction_house: accounts.auction_house.to_account_info(),
-            auction_house_fee_account: accounts.auction_house_fee_account.to_account_info(),
-            seller_trade_state: accounts.seller_trade_state.to_account_info(),
-            free_seller_trade_state: accounts.free_seller_trade_state.to_account_info(),
-            authority: accounts.authority.to_account_info(),
-            auctioneer_authority: accounts.reward_center.to_account_info(),
-            ah_auctioneer_pda: accounts.ah_auctioneer_pda.to_account_info(),
-            token_program: accounts.token_program.to_account_info(),
-            system_program: accounts.system_program.to_account_info(),
-            program_as_signer: accounts.program_as_signer.to_account_info(),
-            rent: accounts.rent.to_account_info(),
-        }
-    }
 }

--- a/listing-rewards/program/src/listings/create/mod.rs
+++ b/listing-rewards/program/src/listings/create/mod.rs
@@ -247,7 +247,7 @@ pub fn handler(
         token_size,
     };
 
-    let signer_required_keys = [
+    let signer_required_keys = vec![
         ctx.accounts.reward_center.key(),
         ctx.accounts.wallet.key(),
     ];

--- a/listing-rewards/program/src/listings/create/mod.rs
+++ b/listing-rewards/program/src/listings/create/mod.rs
@@ -196,8 +196,6 @@ pub fn handler(
     let wallet = &ctx.accounts.wallet;
     let clock = Clock::get()?;
     let auction_house_key = auction_house.key();
-    let wallet_key = ctx.accounts.wallet.key();
-    let auction_house_authority_key = ctx.accounts.authority.key();
 
     assert_belongs_to_rewardable_collection(metadata, rewardable_collection)?;
 

--- a/listing-rewards/program/src/offers/close/mod.rs
+++ b/listing-rewards/program/src/offers/close/mod.rs
@@ -171,8 +171,6 @@ pub fn handler(
     let rewardable_collection = &ctx.accounts.rewardable_collection;
     let wallet = &ctx.accounts.wallet;
     let auction_house_key = auction_house.key();
-    let wallet_key = ctx.accounts.wallet.key();
-    let auction_house_authority_key = ctx.accounts.authority.key();
 
     assert_belongs_to_rewardable_collection(metadata, rewardable_collection)?;
 
@@ -215,6 +213,7 @@ pub fn handler(
 
     // Cancel (Close Offer) instruction via invoke_signed
 
+    let auction_house_program = ctx.accounts.auction_house_program.to_account_info();
     let close_offer_ctx_accounts = AuctioneerCancel {
         wallet: ctx.accounts.wallet.to_account_info(),
         token_account: ctx.accounts.token_account.to_account_info(),
@@ -233,33 +232,21 @@ pub fn handler(
         token_size,
     };
 
-    let auth_account_key = if auction_house.requires_sign_off {
-        auction_house_authority_key
-    } else {
-        wallet_key
-    };
-
-    let signer_required_keys = vec![ctx.accounts.reward_center.key(), auth_account_key];
-
     let close_offer_ix = Instruction {
-        program_id: ctx.accounts.auction_house_program.key(),
+        program_id: auction_house_program.key(),
         data: close_offer_params.data(),
         accounts: close_offer_ctx_accounts
-            .to_account_metas(None)
-            .into_iter()
-            .map(|mut account| {
-                if signer_required_keys.contains(&account.pubkey) {
-                    account.is_signer = if account.pubkey.eq(&reward_center.key()) {
-                        true
-                    } else if account.pubkey.eq(&wallet_key) {
-                        ctx.accounts.wallet.to_account_info().is_signer
-                    } else {
-                        ctx.accounts.authority.to_account_info().is_signer
-                    }
-                }
-                account
-            })
-            .collect(),
+        .to_account_metas(None)
+        .into_iter()
+        .zip(close_offer_ctx_accounts.to_account_infos())
+        .map(|mut pair| {
+            pair.0.is_signer = pair.1.is_signer;
+            if pair.0.pubkey == ctx.accounts.reward_center.key() {
+                pair.0.is_signer = true;
+            }
+            pair.0
+        })
+        .collect()
     };
 
     invoke_signed(

--- a/listing-rewards/program/src/rewardable_collection/delete/mod.rs
+++ b/listing-rewards/program/src/rewardable_collection/delete/mod.rs
@@ -8,7 +8,6 @@ use crate::{
     state::{RewardCenter, RewardableCollection},
 };
 
-
 #[derive(AnchorSerialize, AnchorDeserialize, Debug)]
 pub struct DeleteRewardableCollectionParams {
     pub collection: Pubkey,


### PR DESCRIPTION
The Signer requirement for create/cancel listings have been reverted in their respective auction house program instructions, and the CPI calls are invoked through solana's native invoke_signed methodology.