### PR TITLE
chore: change Auctioneer PDA type

### DIFF
--- a/listing-rewards/program/Cargo.lock
+++ b/listing-rewards/program/Cargo.lock
@@ -1641,36 +1641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metaplex-token-metadata"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abcc939f0afdc6db054b9998a1292d0a016244b382462e61cfc7c570624982cb"
-dependencies = [
- "arrayref",
- "borsh",
- "metaplex-token-vault",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-token",
- "thiserror",
-]
-
-[[package]]
-name = "metaplex-token-vault"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5211991ba3273df89cd5e0f6f558bc8d7453c87c0546f915b4a319e1541df33"
-dependencies = [
- "borsh",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-token",
- "thiserror",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,12 +1679,11 @@ dependencies = [
 
 [[package]]
 name = "mpl-auction-house"
-version = "1.2.0"
+version = "1.2.4"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
  "arrayref",
- "metaplex-token-metadata",
  "mpl-token-metadata",
  "solana-program",
  "spl-associated-token-account",
@@ -1773,11 +1742,11 @@ dependencies = [
  "anchor-client",
  "borsh",
  "mpl-token-metadata",
- "mpl-token-vault 0.1.1",
+ "mpl-token-vault",
  "num",
  "num-derive",
  "num-traits",
- "rand 0.7.3",
+ "rand 0.8.5",
  "serde_json",
  "shellexpand",
  "solana-program",
@@ -1795,25 +1764,12 @@ checksum = "741990cd07cb31d009a345806f30ace8eab99c063cd9440eba8d3df7be2a6988"
 dependencies = [
  "arrayref",
  "borsh",
- "mpl-token-vault 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mpl-token-vault",
  "num-derive",
  "num-traits",
  "shank",
  "solana-program",
  "spl-associated-token-account",
- "spl-token",
- "thiserror",
-]
-
-[[package]]
-name = "mpl-token-vault"
-version = "0.1.1"
-dependencies = [
- "borsh",
- "num-derive",
- "num-traits",
- "shank",
- "solana-program",
  "spl-token",
  "thiserror",
 ]

--- a/listing-rewards/program/src/execute_sale/mod.rs
+++ b/listing-rewards/program/src/execute_sale/mod.rs
@@ -242,7 +242,7 @@ pub struct ExecuteSale<'info> {
             reward_center.key().as_ref()
         ],
         seeds::program = auction_house_program,
-        bump = auction_house.auctioneer_pda_bump
+        bump = ah_auctioneer_pda.bump
     )]
     pub ah_auctioneer_pda: Box<Account<'info, Auctioneer>>,
 

--- a/listing-rewards/program/src/listings/cancel/mod.rs
+++ b/listing-rewards/program/src/listings/cancel/mod.rs
@@ -11,6 +11,7 @@ use mpl_auction_house::{
     instruction::AuctioneerCancel as AuctioneerCancelParams,
     program::AuctionHouse as AuctionHouseProgram,
     AuctionHouse,
+    Auctioneer
 };
 use solana_program::{instruction::Instruction, program::invoke_signed};
 
@@ -106,9 +107,9 @@ pub struct CancelListing<'info> {
             reward_center.key().as_ref()
         ],
         seeds::program = auction_house_program,
-        bump = auction_house.auctioneer_pda_bump
+        bump = ah_auctioneer_pda.bump
     )]
-    pub ah_auctioneer_pda: UncheckedAccount<'info>,
+    pub ah_auctioneer_pda: Box<Account<'info, Auctioneer>>,
 
     pub token_program: Program<'info, Token>,
     pub auction_house_program: Program<'info, AuctionHouseProgram>,

--- a/listing-rewards/program/src/listings/create/mod.rs
+++ b/listing-rewards/program/src/listings/create/mod.rs
@@ -14,6 +14,7 @@ use mpl_auction_house::{
     instruction::AuctioneerSell as AuctioneerSellParams,
     program::AuctionHouse as AuctionHouseProgram,
     AuctionHouse,
+    Auctioneer
 };
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
@@ -153,9 +154,9 @@ pub struct CreateListing<'info> {
             reward_center.key().as_ref()
         ],
         seeds::program = auction_house_program,
-        bump = auction_house.auctioneer_pda_bump
+        bump = ah_auctioneer_pda.bump,
     )]
-    pub ah_auctioneer_pda: UncheckedAccount<'info>,
+    pub ah_auctioneer_pda: Box<Account<'info, Auctioneer>>,
 
     /// CHECK: Not dangerous. Account seeds checked in constraint.
     #[account(
@@ -186,6 +187,10 @@ pub fn handler(
     let metadata = &ctx.accounts.metadata;
     let reward_center = &ctx.accounts.reward_center;
     let auction_house = &ctx.accounts.auction_house;
+    let ah_auctioneer_pda = &ctx.accounts.ah_auctioneer_pda;
+
+    msg!("Bump: {}", ah_auctioneer_pda.bump);
+
     let wallet = &ctx.accounts.wallet;
     let clock = Clock::get()?;
     let listing = &mut ctx.accounts.listing;

--- a/listing-rewards/program/src/listings/create/mod.rs
+++ b/listing-rewards/program/src/listings/create/mod.rs
@@ -189,8 +189,6 @@ pub fn handler(
     let auction_house = &ctx.accounts.auction_house;
     let ah_auctioneer_pda = &ctx.accounts.ah_auctioneer_pda;
 
-    msg!("Bump: {}", ah_auctioneer_pda.bump);
-
     let wallet = &ctx.accounts.wallet;
     let clock = Clock::get()?;
     let listing = &mut ctx.accounts.listing;

--- a/listing-rewards/program/src/offers/close/mod.rs
+++ b/listing-rewards/program/src/offers/close/mod.rs
@@ -9,6 +9,7 @@ use mpl_auction_house::{
     instruction::AuctioneerCancel as AuctioneerCancelParams,
     program::AuctionHouse as AuctionHouseProgram,
     AuctionHouse,
+    Auctioneer,
 };
 
 use crate::{
@@ -133,9 +134,9 @@ pub struct CloseOffer<'info> {
             reward_center.key().as_ref()
         ],
         seeds::program = auction_house_program,
-        bump = auction_house.auctioneer_pda_bump
+        bump = ah_auctioneer_pda.bump
     )]
-    pub ah_auctioneer_pda: UncheckedAccount<'info>,
+    pub ah_auctioneer_pda: Box<Account<'info, Auctioneer>>,
 
     pub auction_house_program: Program<'info, AuctionHouseProgram>,
     pub ata_program: Program<'info, AssociatedToken>,

--- a/listing-rewards/program/src/offers/create/mod.rs
+++ b/listing-rewards/program/src/offers/create/mod.rs
@@ -11,6 +11,7 @@ use mpl_auction_house::{
     cpi::accounts::{AuctioneerDeposit, AuctioneerPublicBuy},
     program::AuctionHouse as AuctionHouseProgram,
     AuctionHouse,
+    Auctioneer,
 };
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
@@ -137,9 +138,9 @@ pub struct CreateOffer<'info> {
             reward_center.key().as_ref()
         ],
         seeds::program = auction_house_program,
-        bump = auction_house.auctioneer_pda_bump
+        bump = ah_auctioneer_pda.bump
     )]
-    pub ah_auctioneer_pda: UncheckedAccount<'info>,
+    pub ah_auctioneer_pda: Box<Account<'info, Auctioneer>>,
 
     pub auction_house_program: Program<'info, AuctionHouseProgram>,
     pub token_program: Program<'info, Token>,

--- a/listing-rewards/program/src/offers/update/mod.rs
+++ b/listing-rewards/program/src/offers/update/mod.rs
@@ -11,6 +11,7 @@ use mpl_auction_house::{
     },
     program::AuctionHouse as AuctionHouseProgram,
     AuctionHouse,
+    Auctioneer,
 };
 use solana_program::{instruction::Instruction, program::invoke_signed};
 
@@ -134,9 +135,9 @@ pub struct UpdateOffer<'info> {
             reward_center.key().as_ref()
         ],
         seeds::program = auction_house_program,
-        bump = auction_house.auctioneer_pda_bump
+        bump = ah_auctioneer_pda.bump
     )]
-    pub ah_auctioneer_pda: UncheckedAccount<'info>,
+    pub ah_auctioneer_pda: Box<Account<'info, Auctioneer>>,
 
     pub auction_house_program: Program<'info, AuctionHouseProgram>,
     pub ata_program: Program<'info, AssociatedToken>,

--- a/listing-rewards/sdk/Cargo.lock
+++ b/listing-rewards/sdk/Cargo.lock
@@ -1556,36 +1556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metaplex-token-metadata"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abcc939f0afdc6db054b9998a1292d0a016244b382462e61cfc7c570624982cb"
-dependencies = [
- "arrayref",
- "borsh",
- "metaplex-token-vault",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-token",
- "thiserror",
-]
-
-[[package]]
-name = "metaplex-token-vault"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5211991ba3273df89cd5e0f6f558bc8d7453c87c0546f915b4a319e1541df33"
-dependencies = [
- "borsh",
- "num-derive",
- "num-traits",
- "solana-program",
- "spl-token",
- "thiserror",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,12 +1594,11 @@ dependencies = [
 
 [[package]]
 name = "mpl-auction-house"
-version = "1.2.0"
+version = "1.2.4"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
  "arrayref",
- "metaplex-token-metadata",
  "mpl-token-metadata",
  "solana-program",
  "spl-associated-token-account",


### PR DESCRIPTION
Auctioneer PDA accounts are now typed under `Account<'info, Auctioneer>`