### PR TITLE
feat: add purchase ticket account on execute_sale

### DIFF
--- a/listing-rewards/program/src/assertions.rs
+++ b/listing-rewards/program/src/assertions.rs
@@ -18,7 +18,7 @@ pub fn assert_listing_reward_redemption_eligibility(
         return err!(ListingRewardsError::RewardsAlreadyClaimed);
     }
 
-    if eligibility_timestamp >= current_timestamp || listing.purchased_at.is_some() {
+    if eligibility_timestamp >= current_timestamp || listing.purchase_ticket.is_some() {
         return Ok(());
     }
 
@@ -26,7 +26,9 @@ pub fn assert_listing_reward_redemption_eligibility(
 }
 
 pub fn assert_listing_init_eligibility(listing: &Account<Listing>) -> Result<()> {
-    if listing.is_initialized && (listing.canceled_at.is_none() && listing.purchased_at.is_none()) {
+    if listing.is_initialized
+        && (listing.canceled_at.is_none() && listing.purchase_ticket.is_none())
+    {
         return err!(ListingRewardsError::ListingAlreadyExists);
     }
 
@@ -34,7 +36,7 @@ pub fn assert_listing_init_eligibility(listing: &Account<Listing>) -> Result<()>
 }
 
 pub fn assert_offer_init_eligibility(offer: &Account<Offer>) -> Result<()> {
-    if offer.is_initialized && (offer.canceled_at.is_none() && offer.purchased_at.is_none()) {
+    if offer.is_initialized && (offer.canceled_at.is_none() && offer.purchase_ticket.is_none()) {
         return err!(ListingRewardsError::OfferAlreadyExists);
     }
     Ok(())

--- a/listing-rewards/program/src/constants.rs
+++ b/listing-rewards/program/src/constants.rs
@@ -3,3 +3,5 @@ pub const REWARD_CENTER: &str = "reward_center";
 pub const LISTING: &str = "listing";
 
 pub const OFFER: &str = "offer";
+
+pub const PURCHASE_TICKET: &str = "purchase_ticket";

--- a/listing-rewards/program/src/execute_sale/mod.rs
+++ b/listing-rewards/program/src/execute_sale/mod.rs
@@ -88,7 +88,7 @@ pub struct ExecuteSale<'info> {
 
     /// The purchase ticket that would be initialized to record an executed sale
     #[account(
-        init,
+        init_if_needed,
         space = PurchaseTicket::size(),
         payer = payer,
         seeds = [

--- a/listing-rewards/program/src/listings/create/mod.rs
+++ b/listing-rewards/program/src/listings/create/mod.rs
@@ -207,7 +207,7 @@ pub fn handler(
         .ok_or(ListingRewardsError::BumpSeedNotInHashMap)?;
     listing.created_at = clock.unix_timestamp;
     listing.canceled_at = None;
-    listing.purchased_at = None;
+    listing.purchase_ticket = None;
     listing.reward_redeemed_at = None;
 
     let reward_center_signer_seeds: &[&[&[u8]]] = &[&[

--- a/listing-rewards/program/src/listings/update/mod.rs
+++ b/listing-rewards/program/src/listings/update/mod.rs
@@ -29,7 +29,7 @@ pub struct UpdateListing<'info> {
         has_one = metadata,
         has_one = reward_center,
         constraint = listing.canceled_at.is_none() @ ListingRewardsError::ListingAlreadyCancelled,
-        constraint = listing.purchased_at.is_none() @ ListingRewardsError::ListingAlreadyPurchased,
+        constraint = listing.purchase_ticket.is_none() @ ListingRewardsError::ListingAlreadyPurchased,
         seeds = [
             LISTING.as_bytes(),
             wallet.key().as_ref(),

--- a/listing-rewards/program/src/offers/create/mod.rs
+++ b/listing-rewards/program/src/offers/create/mod.rs
@@ -181,7 +181,7 @@ pub fn handler(
         .ok_or(ListingRewardsError::BumpSeedNotInHashMap)?;
     offer.created_at = clock.unix_timestamp;
     offer.canceled_at = None;
-    offer.purchased_at = None;
+    offer.purchase_ticket = None;
 
     let reward_center_signer_seeds: &[&[&[u8]]] = &[&[
         REWARD_CENTER.as_bytes(),

--- a/listing-rewards/program/src/offers/update/mod.rs
+++ b/listing-rewards/program/src/offers/update/mod.rs
@@ -40,7 +40,7 @@ pub struct UpdateOffer<'info> {
         has_one = reward_center,
         has_one = metadata,
         constraint = offer.canceled_at.is_none() @ ListingRewardsError::OfferAlreadyCancelled,
-        constraint = offer.purchased_at.is_none() @ ListingRewardsError::OfferAlreadyPurchased,
+        constraint = offer.purchase_ticket.is_none() @ ListingRewardsError::OfferAlreadyPurchased,
         seeds = [
             OFFER.as_bytes(),
             wallet.key().as_ref(),

--- a/listing-rewards/program/src/pda.rs
+++ b/listing-rewards/program/src/pda.rs
@@ -6,6 +6,13 @@ pub fn find_reward_center_address(auction_house: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[REWARD_CENTER.as_bytes(), auction_house.as_ref()], &id())
 }
 
+pub fn find_purchase_ticket_address(listing: &Pubkey, offer: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[PURCHASE_TICKET.as_bytes(), listing.as_ref(), offer.as_ref()],
+        &id(),
+    )
+}
+
 pub fn find_listing_address(
     seller: &Pubkey,
     metadata: &Pubkey,

--- a/listing-rewards/program/src/state.rs
+++ b/listing-rewards/program/src/state.rs
@@ -69,7 +69,7 @@ pub struct Listing {
     pub bump: u8,
     pub created_at: i64,
     pub canceled_at: Option<i64>,
-    pub purchased_at: Option<i64>,
+    pub purchase_ticket: Option<Pubkey>,
     pub reward_redeemed_at: Option<i64>,
 }
 
@@ -85,7 +85,7 @@ impl Listing {
         1 + // bump
         8 + // created_at
         1 + 8 + // canceled_at
-        1 + 8 + // purchased_at
+        1 + 32 + // purchase_ticket
         1 + 8 // reward_redeemed_at
     }
 }
@@ -101,7 +101,7 @@ pub struct Offer {
     pub bump: u8,
     pub created_at: i64,
     pub canceled_at: Option<i64>,
-    pub purchased_at: Option<i64>,
+    pub purchase_ticket: Option<Pubkey>,
 }
 
 impl Offer {
@@ -116,6 +116,30 @@ impl Offer {
         1 + // bump
         8 + // created_at
         1 + 8 + // canceled_at
-        1 + 8 // purchased_at
+        1 + 32 // purchase_ticket
+    }
+}
+
+#[account]
+pub struct PurchaseTicket {
+    pub buyer: Pubkey,
+    pub seller: Pubkey,
+    pub metadata: Pubkey,
+    pub reward_center: Pubkey,
+    pub token_size: u64,
+    pub price: u64,
+    pub created_at: i64,
+}
+
+impl PurchaseTicket {
+    pub fn size() -> usize {
+        8 + // delimiter
+        32 + // buyer
+        32 + // seller
+        32 + // metadata
+        32 + // reward_center
+        32 + // token_size
+        8 + // price
+        8 // created_at
     }
 }

--- a/listing-rewards/program/tests/execute_sale.rs
+++ b/listing-rewards/program/tests/execute_sale.rs
@@ -301,7 +301,6 @@ async fn execute_sale_success() {
     context.warp_to_slot(120 * 400).unwrap();
 
     // EXECUTE SALE TEST
-
     let auction_house_fee_account = &find_auction_house_fee_account_address(&auction_house).0;
 
     airdrop(
@@ -324,6 +323,7 @@ async fn execute_sale_success() {
     let execute_sale_accounts = ExecuteSaleAccounts {
         auction_house,
         token_account,
+        payer: wallet,
         buyer: buyer.pubkey(),
         seller: metadata_owner.pubkey(),
         authority: wallet,

--- a/listing-rewards/program/tests/reopen_purchased_listing.rs
+++ b/listing-rewards/program/tests/reopen_purchased_listing.rs
@@ -327,6 +327,7 @@ async fn reopen_purchased_listing_success() {
         buyer: buyer.pubkey(),
         seller: metadata_owner.pubkey(),
         authority: wallet,
+        payer: wallet,
         token_mint: metadata_mint_address,
         treasury_mint: mint,
         buyer_receipt_token_account: buyer_token_account,

--- a/listing-rewards/program/tests/reopen_purchased_offer.rs
+++ b/listing-rewards/program/tests/reopen_purchased_offer.rs
@@ -325,6 +325,7 @@ async fn reopen_purchased_listing_success() {
         auction_house,
         token_account,
         buyer: buyer.pubkey(),
+        payer: wallet,
         seller: metadata_owner.pubkey(),
         authority: wallet,
         token_mint: metadata_mint_address,

--- a/listing-rewards/sdk/Cargo.lock
+++ b/listing-rewards/sdk/Cargo.lock
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "mpl-listing-rewards"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",

--- a/listing-rewards/sdk/src/accounts.rs
+++ b/listing-rewards/sdk/src/accounts.rs
@@ -71,6 +71,7 @@ pub struct CloseOfferAccounts {
 pub struct ExecuteSaleAccounts {
     pub buyer: Pubkey,
     pub seller: Pubkey,
+    pub payer: Pubkey,
     pub authority: Pubkey,
     pub auction_house: Pubkey,
     pub treasury_mint: Pubkey,

--- a/listing-rewards/sdk/src/lib.rs
+++ b/listing-rewards/sdk/src/lib.rs
@@ -17,7 +17,10 @@ use mpl_listing_rewards::{
         cancel::CancelListingParams, create::CreateListingParams, update::UpdateListingParams,
     },
     offers::{close::CloseOfferParams, create::CreateOfferParams, update::UpdateOfferParams},
-    pda::{self, find_listing_address, find_offer_address, find_reward_center_address},
+    pda::{
+        self, find_listing_address, find_offer_address, find_purchase_ticket_address,
+        find_reward_center_address,
+    },
     reward_center::{create::CreateRewardCenterParams, edit::EditRewardCenterParams},
 };
 use spl_associated_token_account::get_associated_token_address;
@@ -453,6 +456,7 @@ pub fn execute_sale(
         auction_house,
         seller,
         buyer,
+        payer,
         authority,
         treasury_mint,
         token_mint,
@@ -470,6 +474,7 @@ pub fn execute_sale(
     let (reward_center, _) = find_reward_center_address(&auction_house);
     let (offer, _) = find_offer_address(&buyer, &metadata, &reward_center);
     let (listing, _) = find_listing_address(&seller, &metadata, &reward_center);
+    let (purchase_ticket, _) = find_purchase_ticket_address(&listing, &offer);
 
     let (auction_house_fee_account, _) =
         mpl_auction_house::pda::find_auction_house_fee_account_address(&auction_house);
@@ -522,6 +527,8 @@ pub fn execute_sale(
         seller_reward_token_account,
         listing,
         offer,
+        payer,
+        purchase_ticket,
         authority,
         treasury_mint,
         token_mint,


### PR DESCRIPTION
On sale execution, a purchase ticket account is initialized with necessary fields, aiding towards indexing price and other necessary fields. 

Closes #26