### PR TITLE
feat: dynamic payout numeral listing rewards program

### DIFF
--- a/reward-center/program/src/state/mod.rs
+++ b/reward-center/program/src/state/mod.rs
@@ -5,11 +5,21 @@ use anchor_lang::prelude::*;
 use crate::errors::ListingRewardsError;
 
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug)]
+pub enum PayoutOperation {
+    Multiple,
+    Divide,
+}
+
+#[derive(AnchorDeserialize, AnchorSerialize, Clone, Debug)]
 pub struct RewardRules {
     // Basis Points to determine reward ratio for seller
     pub seller_reward_payout_basis_points: u16,
-    // Payout Divider for determining reward distribution to seller/buyer
-    pub payout_divider: u16,
+
+    // Payout operation to consider when taking payout_numeral into account
+    pub mathematical_operand: PayoutOperation,
+
+    // Payout numeral for determining reward distribution to seller/buyer
+    pub payout_numeral: u16,
 }
 
 #[account]
@@ -35,19 +45,40 @@ impl RewardCenter {
         1 // bump
     }
 
+    pub fn calculate_total_token_payout(
+        &self,
+        listing_price: u64,
+        payout_operation: &PayoutOperation,
+    ) -> u64 {
+        match payout_operation {
+            PayoutOperation::Multiple => {
+                msg!("Payout operation mode: Multiple");
+                return listing_price
+                    .checked_mul(self.reward_rules.payout_numeral.into())
+                    .ok_or(ListingRewardsError::NumericalOverflowError)
+                    .unwrap();
+            }
+
+            PayoutOperation::Divide => {
+                msg!("Payout operation mode: Divide");
+                return listing_price
+                    .checked_div(self.reward_rules.payout_numeral.into())
+                    .ok_or(ListingRewardsError::NumericalOverflowError)
+                    .unwrap();
+            }
+        }
+    }
+
     // TODO: review the effects of decimals on the payouts. The math is clean when the currency token is the same as the reward token.
     pub fn payouts(&self, listing_price: u64) -> Result<(u64, u64)> {
-        let total_token_payout = listing_price
-            .checked_div(self.reward_rules.payout_divider.into())
-            .ok_or(ListingRewardsError::NumericalOverflowError)?
-            as u64;
+        let total_token_payout = self
+            .calculate_total_token_payout(listing_price, &self.reward_rules.mathematical_operand);
 
         let seller_share = self.reward_rules.seller_reward_payout_basis_points;
 
         let seller_payout = (seller_share as u128)
             .checked_mul(total_token_payout as u128)
-            .ok_or(ListingRewardsError::NumericalOverflowError)?
-            .checked_div(10000)
+            .and_then(|product| product.checked_div(10000))
             .ok_or(ListingRewardsError::NumericalOverflowError)? as u64;
 
         let buyer_payout = total_token_payout

--- a/reward-center/program/src/state/mod.rs
+++ b/reward-center/program/src/state/mod.rs
@@ -45,7 +45,7 @@ impl RewardCenter {
         1 // bump
     }
 
-    pub fn calculate_total_token_payout(
+    fn calculate_total_token_payout(
         &self,
         listing_price: u64,
         payout_operation: &PayoutOperation,

--- a/reward-center/program/tests/cancel_listing.rs
+++ b/reward-center/program/tests/cancel_listing.rs
@@ -2,7 +2,6 @@
 
 pub mod reward_center_test;
 
-use crate::state::base::*;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 use mpl_auction_house::{
     pda::{
@@ -11,9 +10,9 @@ use mpl_auction_house::{
     AuthorityScope,
 };
 use mpl_reward_center::{
-    mut_reward_center,
     pda::{find_listing_address, find_reward_center_address},
-    state,
+    reward_centers,
+    state::*,
 };
 use reward_center_test::fixtures::metadata;
 
@@ -127,10 +126,11 @@ async fn cancel_listing_success() {
     )
     .unwrap();
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 

--- a/reward-center/program/tests/cancel_offer.rs
+++ b/reward-center/program/tests/cancel_offer.rs
@@ -2,7 +2,6 @@
 
 pub mod reward_center_test;
 
-use crate::state::base::*;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 use mpl_auction_house::{
     pda::{
@@ -11,9 +10,9 @@ use mpl_auction_house::{
     AuthorityScope,
 };
 use mpl_reward_center::{
-    mut_reward_center,
     pda::{find_listing_address, find_reward_center_address},
-    state,
+    reward_centers,
+    state::*,
 };
 use reward_center_test::fixtures::metadata;
 
@@ -126,10 +125,11 @@ async fn cancel_offer_success() {
     )
     .unwrap();
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 

--- a/reward-center/program/tests/create_listing.rs
+++ b/reward-center/program/tests/create_listing.rs
@@ -1,8 +1,6 @@
 #![cfg(feature = "test-bpf")]
 
 pub mod reward_center_test;
-
-use crate::state::base::*;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 use mpl_auction_house::{
     pda::{
@@ -11,9 +9,9 @@ use mpl_auction_house::{
     AuthorityScope,
 };
 use mpl_reward_center::{
-    mut_reward_center,
     pda::{find_listing_address, find_reward_center_address},
-    state,
+    reward_centers,
+    state::*,
 };
 use reward_center_test::fixtures::metadata;
 
@@ -122,10 +120,11 @@ async fn create_listing_success() {
     )
     .unwrap();
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 

--- a/reward-center/program/tests/create_offer.rs
+++ b/reward-center/program/tests/create_offer.rs
@@ -1,8 +1,6 @@
 #![cfg(feature = "test-bpf")]
 
 pub mod reward_center_test;
-
-use crate::state::base::*;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 use mpl_auction_house::{
     pda::{
@@ -11,9 +9,9 @@ use mpl_auction_house::{
     AuthorityScope,
 };
 use mpl_reward_center::{
-    mut_reward_center,
     pda::{find_listing_address, find_reward_center_address},
-    state,
+    reward_centers,
+    state::*,
 };
 use reward_center_test::fixtures::metadata;
 
@@ -126,10 +124,11 @@ async fn create_offer_success() {
     )
     .unwrap();
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 

--- a/reward-center/program/tests/create_reward_center.rs
+++ b/reward-center/program/tests/create_reward_center.rs
@@ -1,11 +1,9 @@
 #![cfg(feature = "test-bpf")]
 
 pub mod reward_center_test;
-
-use crate::state::base::*;
 use anchor_client::solana_sdk::{signature::Signer, transaction::Transaction};
 use mpl_auction_house::pda::find_auction_house_address;
-use mpl_reward_center::{mut_reward_center, pda::find_reward_center_address, state};
+use mpl_reward_center::{pda::find_reward_center_address, reward_centers, state::*};
 
 use mpl_testing_utils::solana::airdrop;
 use solana_program_test::*;
@@ -80,10 +78,11 @@ async fn create_reward_center_success() {
     )
     .unwrap();
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 

--- a/reward-center/program/tests/edit_reward_center.rs
+++ b/reward-center/program/tests/edit_reward_center.rs
@@ -1,11 +1,9 @@
 #![cfg(feature = "test-bpf")]
 
 pub mod reward_center_test;
-
-use crate::state::base::*;
 use anchor_client::solana_sdk::{signature::Signer, transaction::Transaction};
 use mpl_auction_house::pda::find_auction_house_address;
-use mpl_reward_center::{mut_reward_center, pda::find_reward_center_address, state};
+use mpl_reward_center::{pda::find_reward_center_address, reward_centers, state::*};
 
 use mpl_testing_utils::solana::airdrop;
 use solana_program_test::*;
@@ -80,17 +78,19 @@ async fn edit_reward_center_success() {
     )
     .unwrap();
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 
-    let edit_reward_center_params = mut_reward_center::edit::EditRewardCenterParams {
+    let edit_reward_center_params = reward_centers::edit::EditRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Multiple,
             seller_reward_payout_basis_points: 2000,
-            payout_divider: 10,
+            payout_numeral: 10,
         },
     };
 

--- a/reward-center/program/tests/execute_sale_divide.rs
+++ b/reward-center/program/tests/execute_sale_divide.rs
@@ -1,0 +1,360 @@
+#![cfg(feature = "test-bpf")]
+
+pub mod reward_center_test;
+use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
+use mpl_auction_house::{
+    pda::{
+        find_auction_house_address, find_auction_house_fee_account_address,
+        find_auctioneer_trade_state_address, find_trade_state_address,
+    },
+    AuthorityScope,
+};
+use mpl_reward_center::{
+    pda::{find_listing_address, find_reward_center_address},
+    reward_centers,
+    state::*,
+};
+use reward_center_test::fixtures::metadata;
+
+use mpl_reward_center_sdk::{
+    accounts::{ExecuteSaleAccounts, *},
+    args::{ExecuteSaleData, *},
+    *,
+};
+
+use mpl_testing_utils::solana::airdrop;
+use solana_program_test::*;
+use solana_sdk::{program_pack::Pack, signature::Keypair, system_instruction::create_account};
+use std::str::FromStr;
+
+use mpl_token_metadata::state::Collection;
+
+use spl_associated_token_account::{create_associated_token_account, get_associated_token_address};
+use spl_token::{
+    instruction::{initialize_mint, mint_to_checked},
+    native_mint,
+    state::Mint,
+};
+
+#[tokio::test]
+async fn execute_sale_divide_success() {
+    let program = reward_center_test::setup_program();
+    let mut context = program.start_with_context().await;
+    let rent = context.banks_client.get_rent().await.unwrap();
+    let wallet = context.payer.pubkey();
+    let mint = native_mint::id();
+    let collection = Pubkey::from_str(reward_center_test::TEST_COLLECTION).unwrap();
+
+    let metadata = metadata::create(
+        &mut context,
+        metadata::Params {
+            name: "Test",
+            symbol: "TST",
+            uri: "https://nfts.exp.com/1.json",
+            creators: None,
+            seller_fee_basis_points: 10,
+            is_mutable: false,
+            collection: Some(Collection {
+                verified: false,
+                key: collection,
+            }),
+            uses: None,
+        },
+        None,
+    )
+    .await;
+
+    let metadata_owner = metadata.token;
+    let metadata_address = metadata.pubkey;
+    let metadata_owner_address = metadata_owner.pubkey();
+    let metadata_mint_address = metadata.mint.pubkey();
+
+    let (auction_house, _) = find_auction_house_address(&wallet, &mint);
+    let (reward_center, _) = find_reward_center_address(&auction_house);
+    let (listing, _) =
+        find_listing_address(&metadata_owner_address, &metadata_address, &reward_center);
+
+    // Creating Rewards mint and token account
+    let token_program = &spl_token::id();
+    let reward_mint_authority_keypair = Keypair::new();
+    let reward_mint_keypair = Keypair::new();
+
+    let reward_mint_authority_pubkey = reward_mint_authority_keypair.pubkey();
+    let reward_mint_pubkey = reward_mint_keypair.pubkey();
+
+    airdrop(
+        &mut context,
+        &reward_mint_authority_pubkey,
+        reward_center_test::TEN_SOL,
+    )
+    .await
+    .unwrap();
+
+    // Assign account and rent
+    let mint_account_rent = rent.minimum_balance(Mint::LEN);
+    let allocate_reward_mint_space_ix = create_account(
+        &reward_mint_authority_pubkey,
+        &reward_mint_pubkey,
+        mint_account_rent,
+        Mint::LEN as u64,
+        &token_program,
+    );
+
+    // Initialize rewards mint
+    let init_rewards_reward_mint_ix = initialize_mint(
+        &token_program,
+        &reward_mint_pubkey,
+        &reward_mint_authority_pubkey,
+        Some(&reward_mint_authority_pubkey),
+        9,
+    )
+    .unwrap();
+
+    // Minting initial tokens to reward_center
+    let reward_center_reward_token_account =
+        get_associated_token_address(&reward_center, &reward_mint_pubkey);
+
+    let mint_reward_tokens_ix = mint_to_checked(
+        &token_program,
+        &reward_mint_pubkey,
+        &reward_center_reward_token_account,
+        &reward_mint_authority_pubkey,
+        &[],
+        100_000_000_000,
+        9,
+    )
+    .unwrap();
+
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
+        reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
+            seller_reward_payout_basis_points: 1000,
+            payout_numeral: 5,
+        },
+    };
+
+    let create_auction_house_accounts = mpl_auction_house_sdk::CreateAuctionHouseAccounts {
+        treasury_mint: mint,
+        payer: wallet,
+        authority: wallet,
+        fee_withdrawal_destination: wallet,
+        treasury_withdrawal_destination: wallet,
+        treasury_withdrawal_destination_owner: wallet,
+    };
+    let create_auction_house_data = mpl_auction_house_sdk::CreateAuctionHouseData {
+        seller_fee_basis_points: 100,
+        requires_sign_off: false,
+        can_change_sale_price: false,
+    };
+
+    let create_auction_house_ix = mpl_auction_house_sdk::create_auction_house(
+        create_auction_house_accounts,
+        create_auction_house_data,
+    );
+
+    let create_reward_center_ix = mpl_reward_center_sdk::create_reward_center(
+        wallet,
+        reward_mint_keypair.pubkey(),
+        auction_house,
+        reward_center_params,
+    );
+
+    let delegate_auctioneer_accounts = mpl_auction_house_sdk::DelegateAuctioneerAccounts {
+        auction_house,
+        authority: wallet,
+        auctioneer_authority: reward_center,
+    };
+
+    let delegate_auctioneer_data = mpl_auction_house_sdk::DelegateAuctioneerData {
+        scopes: vec![
+            AuthorityScope::Deposit,
+            AuthorityScope::Buy,
+            AuthorityScope::PublicBuy,
+            AuthorityScope::ExecuteSale,
+            AuthorityScope::Sell,
+            AuthorityScope::Cancel,
+            AuthorityScope::Withdraw,
+        ],
+    };
+
+    let delegate_auctioneer_ix = mpl_auction_house_sdk::delegate_auctioneer(
+        delegate_auctioneer_accounts,
+        delegate_auctioneer_data,
+    );
+
+    let token_account =
+        get_associated_token_address(&metadata_owner_address, &metadata_mint_address);
+
+    let (seller_trade_state, trade_state_bump) = find_auctioneer_trade_state_address(
+        &metadata_owner_address,
+        &auction_house,
+        &token_account,
+        &mint,
+        &metadata_mint_address,
+        1,
+    );
+
+    let (free_seller_trade_state, free_trade_state_bump) = find_trade_state_address(
+        &metadata_owner_address,
+        &auction_house,
+        &token_account,
+        &mint,
+        &metadata_mint_address,
+        0,
+        1,
+    );
+
+    let create_listing_accounts = CreateListingAccounts {
+        wallet: metadata_owner.pubkey(),
+        listing,
+        reward_center,
+        token_account,
+        metadata: metadata.pubkey,
+        authority: wallet,
+        auction_house,
+        seller_trade_state,
+        free_seller_trade_state,
+    };
+
+    let create_listing_params = CreateListingData {
+        price: reward_center_test::ONE_SOL,
+        token_size: 1,
+        trade_state_bump,
+        free_trade_state_bump,
+    };
+
+    let create_listing_ix = create_listing(create_listing_accounts, create_listing_params);
+
+    let tx = Transaction::new_signed_with_payer(
+        &[
+            create_auction_house_ix,
+            allocate_reward_mint_space_ix,
+            init_rewards_reward_mint_ix,
+            create_reward_center_ix,
+            mint_reward_tokens_ix,
+            delegate_auctioneer_ix,
+        ],
+        Some(&wallet),
+        &[
+            &context.payer,
+            &reward_mint_authority_keypair,
+            &reward_mint_keypair,
+        ],
+        context.last_blockhash,
+    );
+
+    let tx_response = context.banks_client.process_transaction(tx).await;
+
+    assert!(tx_response.is_ok());
+
+    let tx = Transaction::new_signed_with_payer(
+        &[create_listing_ix],
+        Some(&metadata_owner_address),
+        &[&metadata_owner],
+        context.last_blockhash,
+    );
+
+    let tx_response = context.banks_client.process_transaction(tx).await;
+
+    assert!(tx_response.is_ok());
+
+    // CREATE OFFER TEST
+
+    let buyer = Keypair::new();
+    let buyer_pubkey = &buyer.pubkey();
+    airdrop(&mut context, buyer_pubkey, reward_center_test::TEN_SOL)
+        .await
+        .unwrap();
+
+    let create_offer_accounts = CreateOfferAccounts {
+        wallet: *buyer_pubkey,
+        transfer_authority: *buyer_pubkey,
+        payment_account: *buyer_pubkey,
+        treasury_mint: mint,
+        token_mint: metadata_mint_address,
+        auction_house,
+        reward_center,
+        token_account,
+        metadata: metadata_address,
+        authority: wallet,
+    };
+
+    let create_offer_params = CreateOfferData {
+        token_size: 1,
+        buyer_price: reward_center_test::ONE_SOL,
+    };
+
+    let create_offer_ix = create_offer(create_offer_accounts, create_offer_params);
+
+    let tx = Transaction::new_signed_with_payer(
+        &[create_offer_ix],
+        Some(buyer_pubkey),
+        &[&buyer],
+        context.last_blockhash,
+    );
+
+    let tx_response = context.banks_client.process_transaction(tx).await;
+
+    assert!(tx_response.is_ok());
+
+    context.warp_to_slot(120 * 400).unwrap();
+
+    // EXECUTE SALE TEST
+    let auction_house_fee_account = &find_auction_house_fee_account_address(&auction_house).0;
+
+    airdrop(
+        &mut context,
+        auction_house_fee_account,
+        reward_center_test::ONE_SOL,
+    )
+    .await
+    .unwrap();
+
+    // Creating Associated Token accounts
+    let create_buyer_reward_token_ix =
+        create_associated_token_account(&wallet, &buyer_pubkey, &reward_mint_pubkey);
+
+    let create_seller_reward_token_ix =
+        create_associated_token_account(&wallet, &metadata_owner_address, &reward_mint_pubkey);
+
+    let buyer_token_account = get_associated_token_address(&buyer.pubkey(), &metadata_mint_address);
+
+    let execute_sale_accounts = ExecuteSaleAccounts {
+        auction_house,
+        token_account,
+        payer: wallet,
+        buyer: buyer.pubkey(),
+        seller: metadata_owner.pubkey(),
+        authority: wallet,
+        token_mint: metadata_mint_address,
+        treasury_mint: mint,
+        buyer_receipt_token_account: buyer_token_account,
+        seller_payment_receipt_account: metadata_owner.pubkey(),
+        metadata: metadata_address,
+    };
+
+    let execute_sale_params = ExecuteSaleData {
+        price: reward_center_test::ONE_SOL,
+        token_size: 1,
+        reward_mint: reward_mint_pubkey,
+    };
+
+    let execute_sale_ix = execute_sale(execute_sale_accounts, execute_sale_params);
+
+    let tx = Transaction::new_signed_with_payer(
+        &[
+            create_buyer_reward_token_ix,
+            create_seller_reward_token_ix,
+            execute_sale_ix,
+        ],
+        Some(&wallet),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+
+    let tx_response = context.banks_client.process_transaction(tx).await;
+
+    assert!(tx_response.is_ok());
+
+    ()
+}

--- a/reward-center/program/tests/execute_sale_multiple.rs
+++ b/reward-center/program/tests/execute_sale_multiple.rs
@@ -1,8 +1,6 @@
 #![cfg(feature = "test-bpf")]
 
 pub mod reward_center_test;
-
-use crate::state::base::*;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 use mpl_auction_house::{
     pda::{
@@ -12,9 +10,9 @@ use mpl_auction_house::{
     AuthorityScope,
 };
 use mpl_reward_center::{
-    mut_reward_center,
     pda::{find_listing_address, find_reward_center_address},
-    state,
+    reward_centers,
+    state::*,
 };
 use reward_center_test::fixtures::metadata;
 
@@ -39,7 +37,7 @@ use spl_token::{
 };
 
 #[tokio::test]
-async fn execute_sale_success() {
+async fn execute_sale_multiple_success() {
     let program = reward_center_test::setup_program();
     let mut context = program.start_with_context().await;
     let rent = context.banks_client.get_rent().await.unwrap();
@@ -127,10 +125,11 @@ async fn execute_sale_success() {
     )
     .unwrap();
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Multiple,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 

--- a/reward-center/program/tests/redeem_rewards.rs
+++ b/reward-center/program/tests/redeem_rewards.rs
@@ -1,8 +1,6 @@
 #![cfg(feature = "test-bpf")]
 
 pub mod reward_center_test;
-
-use crate::state::base::*;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 use mpl_auction_house::{
     pda::{
@@ -11,9 +9,9 @@ use mpl_auction_house::{
     AuthorityScope,
 };
 use mpl_reward_center::{
-    mut_reward_center,
     pda::{find_listing_address, find_reward_center_address},
-    state,
+    reward_centers,
+    state::*,
 };
 use reward_center_test::fixtures::metadata;
 
@@ -106,10 +104,11 @@ async fn redeem_rewards_success() {
         find_listing_address(&metadata_owner_address, &metadata_address, &reward_center);
     let treasury_withdraw_desintiation = get_associated_token_address(&wallet, &mint.pubkey());
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 

--- a/reward-center/program/tests/reopen_cancelled_listing.rs
+++ b/reward-center/program/tests/reopen_cancelled_listing.rs
@@ -1,8 +1,6 @@
 #![cfg(feature = "test-bpf")]
 
 pub mod reward_center_test;
-
-use crate::state::base::*;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 use mpl_auction_house::{
     pda::{
@@ -11,9 +9,9 @@ use mpl_auction_house::{
     AuthorityScope,
 };
 use mpl_reward_center::{
-    mut_reward_center,
     pda::{find_listing_address, find_reward_center_address},
-    state,
+    reward_centers,
+    state::*,
 };
 use reward_center_test::fixtures::metadata;
 
@@ -127,10 +125,11 @@ async fn reopen_cancelled_listing_success() {
     )
     .unwrap();
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 

--- a/reward-center/program/tests/reopen_closed_offer.rs
+++ b/reward-center/program/tests/reopen_closed_offer.rs
@@ -1,8 +1,6 @@
 #![cfg(feature = "test-bpf")]
 
 pub mod reward_center_test;
-
-use crate::state::base::*;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 use mpl_auction_house::{
     pda::{
@@ -11,15 +9,15 @@ use mpl_auction_house::{
     AuthorityScope,
 };
 use mpl_reward_center::{
-    mut_reward_center,
     pda::{find_listing_address, find_reward_center_address},
-    state,
+    reward_centers,
+    state::*,
 };
 use reward_center_test::fixtures::metadata;
 
 use mpl_reward_center_sdk::{
-    accounts::{CloseOfferAccounts, *},
-    args::{CloseOfferData, *},
+    accounts::{CancelOfferAccounts, *},
+    args::{CancelOfferData, *},
     *,
 };
 
@@ -126,10 +124,11 @@ async fn reopned_closed_offer_success() {
     )
     .unwrap();
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 
@@ -299,7 +298,7 @@ async fn reopned_closed_offer_success() {
 
     // CLOSE OFFER TEST
 
-    let close_offer_accounts = CloseOfferAccounts {
+    let close_offer_accounts = CancelOfferAccounts {
         wallet: *buyer_pubkey,
         treasury_mint: mint,
         token_mint: metadata_mint_address,
@@ -311,12 +310,12 @@ async fn reopned_closed_offer_success() {
         reward_center,
     };
 
-    let close_offer_params = CloseOfferData {
+    let close_offer_params = CancelOfferData {
         token_size: 1,
         buyer_price: reward_center_test::ONE_SOL,
     };
 
-    let close_offer_ix = close_offer(close_offer_accounts, close_offer_params);
+    let close_offer_ix = cancel_offer(close_offer_accounts, close_offer_params);
 
     // REOPEN CLOSED OFFER TEST
 

--- a/reward-center/program/tests/reopen_purchased_listing.rs
+++ b/reward-center/program/tests/reopen_purchased_listing.rs
@@ -1,8 +1,6 @@
 #![cfg(feature = "test-bpf")]
 
 pub mod reward_center_test;
-
-use crate::state::base::*;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 use mpl_auction_house::{
     pda::{
@@ -12,9 +10,9 @@ use mpl_auction_house::{
     AuthorityScope,
 };
 use mpl_reward_center::{
-    mut_reward_center,
     pda::{find_listing_address, find_reward_center_address},
-    state,
+    reward_centers,
+    state::*,
 };
 use reward_center_test::fixtures::metadata;
 
@@ -127,10 +125,11 @@ async fn reopen_purchased_listing_success() {
     )
     .unwrap();
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 

--- a/reward-center/program/tests/reopen_purchased_offer.rs
+++ b/reward-center/program/tests/reopen_purchased_offer.rs
@@ -1,8 +1,6 @@
 #![cfg(feature = "test-bpf")]
 
 pub mod reward_center_test;
-
-use crate::state::base::*;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 use mpl_auction_house::{
     pda::{
@@ -12,9 +10,9 @@ use mpl_auction_house::{
     AuthorityScope,
 };
 use mpl_reward_center::{
-    mut_reward_center,
     pda::{find_listing_address, find_reward_center_address},
-    state,
+    reward_centers,
+    state::*,
 };
 use reward_center_test::fixtures::metadata;
 
@@ -127,10 +125,11 @@ async fn reopen_purchased_listing_success() {
     )
     .unwrap();
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 

--- a/reward-center/program/tests/update_listing.rs
+++ b/reward-center/program/tests/update_listing.rs
@@ -2,7 +2,6 @@
 
 pub mod reward_center_test;
 
-use crate::state::base::*;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 use mpl_auction_house::{
     pda::{
@@ -11,9 +10,9 @@ use mpl_auction_house::{
     AuthorityScope,
 };
 use mpl_reward_center::{
-    mut_reward_center,
     pda::{find_listing_address, find_reward_center_address},
-    state,
+    reward_centers,
+    state::*,
 };
 use reward_center_test::fixtures::metadata;
 
@@ -126,10 +125,11 @@ async fn update_listing_success() {
     )
     .unwrap();
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 

--- a/reward-center/program/tests/update_offer.rs
+++ b/reward-center/program/tests/update_offer.rs
@@ -2,7 +2,6 @@
 
 pub mod reward_center_test;
 
-use crate::state::base::*;
 use anchor_client::solana_sdk::{pubkey::Pubkey, signature::Signer, transaction::Transaction};
 use mpl_auction_house::{
     pda::{
@@ -11,9 +10,9 @@ use mpl_auction_house::{
     AuthorityScope,
 };
 use mpl_reward_center::{
-    mut_reward_center,
     pda::{find_listing_address, find_reward_center_address},
-    state,
+    reward_centers,
+    state::*,
 };
 use reward_center_test::fixtures::metadata;
 
@@ -126,10 +125,11 @@ async fn create_offer_success() {
     )
     .unwrap();
 
-    let reward_center_params = mut_reward_center::create::CreateRewardCenterParams {
+    let reward_center_params = reward_centers::create::CreateRewardCenterParams {
         reward_rules: RewardRules {
+            mathematical_operand: PayoutOperation::Divide,
             seller_reward_payout_basis_points: 1000,
-            payout_divider: 5,
+            payout_numeral: 5,
         },
     };
 

--- a/reward-center/sdk/src/lib.rs
+++ b/reward-center/sdk/src/lib.rs
@@ -16,12 +16,12 @@ use mpl_reward_center::{
     listings::{
         cancel::CancelListingParams, create::CreateListingParams, update::UpdateListingParams,
     },
-    mut_reward_center::{create::CreateRewardCenterParams, edit::EditRewardCenterParams},
-    offers::{close::CancelOfferParams, create::CreateOfferParams, update::UpdateOfferParams},
+    offers::{cancel::CancelOfferParams, create::CreateOfferParams, update::UpdateOfferParams},
     pda::{
         self, find_listing_address, find_offer_address, find_purchase_ticket_address,
         find_reward_center_address,
     },
+    reward_centers::{create::CreateRewardCenterParams, edit::EditRewardCenterParams},
 };
 use spl_associated_token_account::get_associated_token_address;
 
@@ -435,7 +435,7 @@ pub fn cancel_offer(
     .to_account_metas(None);
 
     let data = instruction::CancelOffer {
-        close_offer_params: CancelOfferParams {
+        cancel_offer_params: CancelOfferParams {
             buyer_price,
             escrow_payment_bump,
             token_size,


### PR DESCRIPTION
The reward rules now support payout_operation arithmetic to `Multiple` and `Divide`.

Closes #33 